### PR TITLE
A small typo, and something not working

### DIFF
--- a/ProffieFonts/US_QuigonStaff.h
+++ b/ProffieFonts/US_QuigonStaff.h
@@ -208,7 +208,7 @@ Preset presets[] = {
 
 //	 /*
 // Basic Fonts: 6 by Kyberphonic
-	{ "001_BLUE;;common","tracks/fates.wav",
+	{ "001_BLUE;common","tracks/fates.wav",
 		StylePtr <MasterStyle>
 		() //, "blue"
 	},
@@ -595,7 +595,7 @@ Preset presets[] = {
 		() //, "partyfoul"
 	},
 
-	// Lightsaber of the Bells by Jérôme Tremblay ( Jay DaloRian) 
+	// Lightsaber of the Bells by JÃ©rÃ´me Tremblay ( Jay DaloRian) 
 	{ "102_Lightsaber_Of_The_Bells;common", "tracks/",
 		StylePtr <MasterStyle>
 		() //, "lightsaberofthebells"
@@ -1407,7 +1407,7 @@ Preset presets[] = {
 				>
 			>
 		>
-		() //, “Ezra”
+		() //, Â“EzraÂ”
 	},
 
 

--- a/ProffieFonts/master/Common_Misc.h
+++ b/ProffieFonts/master/Common_Misc.h
@@ -152,7 +152,7 @@ using LOCKUPCLASHCOLOR = Mix<
 >;
 
 // Randomly select between methods of choosing blast position
-using BLAST_SELECT_RANDOM = IntSelectX<
+using BLAST_SELECT_RANDOM = IntSelectX<  // This is no longer working with ProffieOS 7.14, error: "..\ProffieOS_7.14\config\master\Common_Misc.h:155:29: error: 'IntSelectX' does not name a type; did you mean 'IntSelect'?"
 	EffectRandomF<EFFECT_BLAST>,
 	// Select one of the following at random
 	BladeAngle<>,


### PR DESCRIPTION
Hello BlackDragonN001,

I hope this message finds you well.

I really like your work. I found a small typo, an extra ";" in file US_QuigonStaff.h

Also in file Common_Misc.h line 155:
using BLAST_SELECT_RANDOM = IntSelectX<  // This is no longer working with ProffieOS 7.14, error:
"..\ProffieOS_7.14\config\master\Common_Misc.h:155:29: error: 'IntSelectX' does not name a type; did you mean 'IntSelect'?"

What ProffieOS do you use and does it work for you ?

Thank you and best regards,

Olivier